### PR TITLE
💥 Utiliser la branche master de tools pour gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,6 @@ build:
       mkdir -p /etc/systemd/system/docker.service.d
       touch /etc/systemd/system/docker.service.d/http-proxy.conf
       make config build DOCKER_USERNAME=${DOCKER_USERNAME} DOCKER_REGISTRY=${DOCKER_REGISTRY} NPM_REGISTRY=${NPM_REGISTRY} NPM_SSL=false SASS_REGISTRY=${SASS_REGISTRY} MIRROR_DEBIAN=${MIRROR_DEBIAN} THEME_DNUM=${THEME_DNUM} API_URL=${API_URL} API_EMAIL=${API_EMAIL} GIT_BRANCH=${CI_COMMIT_BRANCH}
-      git -C tools checkout feat/docker-custom-registry
       make docker-push DOCKER_REGISTRY=${DOCKER_REGISTRY} DOCKER_PASSWORD=${DOCKER_PASSWORD} DOCKER_USERNAME=${DOCKER_USERNAME} GIT_BRANCH=${CI_COMMIT_BRANCH}
   except:
      - tags


### PR DESCRIPTION
Maintenant on peut utiliser une registry docker custom sur la branche master https://github.com/matchID-project/tools/pull/6 