### PR TITLE
🕰 Utiliser le format unicode pour especifier le format de dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Conditions d'usage et garanties (version alpha)
 
 Ce service est financé sur fonds personnels et est donc offert sans garantie.

--- a/src/components/views/LinkCheckTable.svelte
+++ b/src/components/views/LinkCheckTable.svelte
@@ -346,10 +346,10 @@
     };
 
     const dateFormat = (dateString) => {
-        const format = ($linkOptions.csv.dateFormat || 'DD/MM/YYYY')
-            .replace('DD','$3')
+        const format = ($linkOptions.csv.dateFormat || 'dd/MM/yyyy')
+            .replace('dd','$3')
             .replace('MM','$2')
-            .replace('YYYY','$1');
+            .replace('yyyy','$1');
         return dateString.replace(/(\d{4})(\d{2})(\d{2})/, format);
     };
 

--- a/src/components/views/LinkCheckTable.svelte
+++ b/src/components/views/LinkCheckTable.svelte
@@ -170,7 +170,9 @@
 
     onMount(() => {
         setTimeout(() => {
+          if (subFilteredRows.length) {
             theadHeight = document.getElementById('table-content').offsetHeight;
+          }
         }, 500);
     })
 

--- a/src/components/views/LinkConfigureOptions.svelte
+++ b/src/components/views/LinkConfigureOptions.svelte
@@ -95,7 +95,7 @@
                 sep: {label: "Séparateur", options:[["Point-virgule (;)",";"],["Virgule (,)",","],["Tabulation","\t","Barre verticale (|)",'|'],["Espace"," "]]},
                 quote: {size:3,label: "Délimiteur", options:[['aucun', undefined],['guillemets doubles (")','"'],["guillemets simples (')","'"]]},
                 skipLines: {label: "Lignes sautées:", options: [['aucune',0],[1,1],[2,2],[3,3],[4,4],[5,5]]},
-                dateFormat: {size: 3,label: "Format des dates", options:[['DD/MM/YYYY','DD/MM/YYYY'],['YYYY-MM-DD','YYYY-MM-DD'],['YYYYMMDD','YYYYMMDD'],['DDMMYYYY','DDMMYYYY'],['DD-MM-YYYY','DD-MM-YYYY'],['YYYY/MM/DD']]},
+                dateFormat: {size: 3,label: "Format des dates", options:[['dd/MM/yyyy','dd/MM/yyyy'],['yyyy-MM-dd','yyyy-MM-dd'],['yyyyMMdd','yyyyMMdd'],['ddMMyyyy','ddMMyyyy'],['dd-MM-yyyy','dd-MM-yyyy'],['yyyy/MM/dd']]},
             }
         },
         api: {

--- a/src/components/views/LinkJob.svelte
+++ b/src/components/views/LinkJob.svelte
@@ -153,7 +153,7 @@
         formData.append('skipLines', $linkOptions.csv.skipLines);
         formData.append('candidateNumber', $linkOptions.api.candidateNumber);
         formData.append('pruneScore', $linkOptions.api.pruneScore);
-        formData.append('dateFormat', $linkOptions.csv.dateFormat || 'DD/MM/YYYY');
+        formData.append('dateFormat', $linkOptions.csv.dateFormat || 'dd/MM/yyyy');
         Object.keys($linkMapping && $linkMapping.reverse).map(k => formData.append(k,$linkMapping.reverse[k]));
         if ($linkOptions.csv.type === 'gedcom') {
             formData.append('csv', new Blob([$linkOptions.csv.csv], {type: 'text/csv;charset=utf-8;'}));

--- a/src/components/views/LinkSampleTable.svelte
+++ b/src/components/views/LinkSampleTable.svelte
@@ -68,12 +68,12 @@
     }
 
     const guessTypeRegexp = [
-        [/^[1-2]\d{3}\/[0-1]\d\/[0-3]\d$/, 'date=YYYY/MM/DD'],
-        [/^[1-2]\d{3}-[0-1]\d-[0-3]\d$/, 'date=YYYY-MM-DD'],
-        [/^[1-2]\d{3}[0-1]\d[0-3]\d$/, 'date=YYYYMMDD'],
-        [/^[0-3]\d-[0-1]\d-[1-2]\d{3}$/, 'date=DD-MM-YYYY'],
-        [/^[0-3]\d\/[0-1]\d\/[1-2]\d{3}$/, 'date=DD/MM/YYYY'],
-        [/^[0-3]\d[0-1]\d[1-2]\d{3}$/, 'date=DDMMYYYY'],
+        [/^[1-2]\d{3}\/[0-1]\d\/[0-3]\d$/, 'date=yyyy/MM/dd'],
+        [/^[1-2]\d{3}-[0-1]\d-[0-3]\d$/, 'date=yyyy-MM-dd'],
+        [/^[1-2]\d{3}[0-1]\d[0-3]\d$/, 'date=yyyyMMdd'],
+        [/^[0-3]\d-[0-1]\d-[1-2]\d{3}$/, 'date=dd-MM-yyyy'],
+        [/^[0-3]\d\/[0-1]\d\/[1-2]\d{3}$/, 'date=dd/MM/yyyy'],
+        [/^[0-3]\d[0-1]\d[1-2]\d{3}$/, 'date=ddMMyyyy'],
         [/^\d[0-9a-b]\d{3}/, 'locationCode'],
         [/^[1-2]$/, 'sex=12'],
         [/^[0-1]$/, 'sex=01'],
@@ -343,7 +343,7 @@
             $linkOptions.csv = {
                 sep: '\t',
                 skipLines: 0,
-                dateFormat: 'YYYYMMDD',
+                dateFormat: 'yyyyMMdd',
                 encoding: 'utf-8',
                 type: type,
                 gedcom: tree,


### PR DESCRIPTION
Le format unicode utilise *dd* instead of *DD* and *yyyy* instead of *YYYY* => [reference](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)

Cette PR a vocation à se raccorder à la PR du backend https://github.com/matchID-project/deces-backend/pull/240