### PR TITLE
🧑‍🏫 Explain results

### DIFF
--- a/nginx/default-dev.template
+++ b/nginx/default-dev.template
@@ -116,7 +116,7 @@ server {
     proxy_set_header Connection "upgrade";
   }
 
-  location ~ "^<BACKEND_PROXY_PATH>/(version|search/(csv|json)/.*|updates(/.*)?|updated|id/.*|docs(/.*)?|auth(/confirm)?|register|healthcheck|queue(/.*)?)$" {
+  location ~ "^<BACKEND_PROXY_PATH>/(compare|version|search/(csv|json)/.*|updates(/.*)?|updated|id/.*|docs(/.*)?|auth(/confirm)?|register|healthcheck|queue(/.*)?)$" {
     add_header Access-Control-Allow-Origin '$http_origin';
     limit_req zone=api_misc burst=<API_MISC_USER_BURST>;
     limit_req zone=api_misc_global burst=<API_MISC_GLOBAL_BURST>;

--- a/src/components/tools/runRequest.js
+++ b/src/components/tools/runRequest.js
@@ -13,6 +13,10 @@ export const runSearchRequest = async (body, cache=true) => {
   return await runRequest('search', 'POST', body, cache);
 };
 
+export const runCompareRequest = async (body, cache=true) => {
+  return await runRequest('compare', 'POST', body, cache);
+};
+
 export const runSearchStreamRequest = async (body, cache=true) => {
   return await runRequest('search', 'POST', body, cache, 'csvStream');
 };

--- a/src/components/views/LinkCheckTable.svelte
+++ b/src/components/views/LinkCheckTable.svelte
@@ -111,7 +111,7 @@
                                         style="height:3.25rem;"
                                     >
                                         {#each header.filter(x => (x!=='score') && (x!=='check')).filter((h,index) => index < mappedColumns).map(h => row[$linkResults.header.indexOf(h)]) as col, index}
-                                            <td title={col}>
+                                            <td title={JSON.stringify(selectedExplains && selectedExplains.explain && selectedExplains.explain[$linkMapping.direct[header[index]]])}>
                                                 {@html formatField(col, header[index], row)}
                                             </td>
                                         {/each}
@@ -248,6 +248,7 @@
     }
 
     let selectedScores = undefined;
+    let selectedExplains = undefined;
     const selectRow = async (row) => {
         if (row) {
             const persA = {}
@@ -262,9 +263,8 @@
                 persB[$linkMapping.direct[h]] = row[$linkResults.header.indexOf(headerMapping[$linkMapping.direct[h]])]
               }
             })
-            let response
-            response = await runCompareRequest({personA: persA, personB: persB}, false)
-            console.log(response)
+            const format = $linkOptions.csv.dateFormat || 'dd/MM/yyyy'
+            selectedExplains = await runCompareRequest({personA: persA, personB: persB, params: {dateFormatA: format, dateFormatB: format, explain: true}}, false)
             selectedRow = row[$linkResults.header.indexOf('sourceLineNumber')];
             selectedScores = JSON.parse(get(row,'scores'));
         } else {

--- a/src/components/views/LinkCheckTable.svelte
+++ b/src/components/views/LinkCheckTable.svelte
@@ -154,6 +154,7 @@
         linkOptions
     } from '../tools/stores.js';
     import jsdiff from 'diff';
+    import { runCompareRequest } from '../tools/runRequest.js';
 
     export let actionTitle;
     export let page = 1;
@@ -247,8 +248,23 @@
     }
 
     let selectedScores = undefined;
-    const selectRow = (row) => {
+    const selectRow = async (row) => {
         if (row) {
+            const persA = {}
+            header.filter(x => (x!=='score') && (x!=='check')).filter((h,index) => index < mappedColumns).forEach(h => {
+              persA[$linkMapping.direct[h]] = row[$linkResults.header.indexOf(h)]
+            })
+            const persB = {}
+            header.filter(x => (x!=='score') && (x!=='check')).filter((h,index) => index < mappedColumns).forEach(h => {
+              if ($linkMapping.direct[h] === 'birthDate' || $linkMapping.direct[h] === 'deathDate') {
+                persB[$linkMapping.direct[h]] = dateFormat(row[$linkResults.header.indexOf(headerMapping[$linkMapping.direct[h]])])
+              } else {
+                persB[$linkMapping.direct[h]] = row[$linkResults.header.indexOf(headerMapping[$linkMapping.direct[h]])]
+              }
+            })
+            let response
+            response = await runCompareRequest({personA: persA, personB: persB}, false)
+            console.log(response)
             selectedRow = row[$linkResults.header.indexOf('sourceLineNumber')];
             selectedScores = JSON.parse(get(row,'scores'));
         } else {


### PR DESCRIPTION
En survol sur chaque ligne on peut obtenir plus de détails sur le résultat du score en utilisant l'endpoint `/compare` du backend. 

![2022-03-19_01:12:36](https://user-images.githubusercontent.com/18708179/159098884-aab939d9-fa19-48f6-b5b3-4566cda18581.png)

Cette PR utilise la PR du backend: https://github.com/matchID-project/deces-backend/pull/315