### PR TITLE
🎨 Handle gedcom files with composed name keys

### DIFF
--- a/src/components/views/GedcomPersonCard.svelte
+++ b/src/components/views/GedcomPersonCard.svelte
@@ -157,10 +157,10 @@
     $: if (record) {
         if (record.name) {
             if (!record.givn) {
-                record.givn = record.name.replace(/^\s*(Mr|Monsieur|Madame|Mme|M\.|Mrs)\s+/gi,'').replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1');
+                record.givn = typeof record.name === 'string' ? record.name.replace(/^\s*(Mr|Monsieur|Madame|Mme|M\.|Mrs)\s+/gi,'').replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1') : record.name.givn;
             }
             if (!record.surn) {
-                record.surn = record.name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1');
+                record.surn = typeof record.name === 'string' ? record.name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1') : record.name.surn;
             }
         }
         if (record.birt && record.birt.plac && record.birt.plac.includes(',')) {

--- a/src/components/views/GedcomTree.svelte
+++ b/src/components/views/GedcomTree.svelte
@@ -118,20 +118,41 @@
                     }
                     f.chil.forEach(c => {
                         gedcom[c].pare = parents.filter(p => gedcom[p]).map(p => {
+                          if (typeof gedcom[p].name === 'object' &&
+                            !Array.isArray(gedcom[p].name) &&
+                            gedcom[p].name !== null) {
+
+                            return {
+                                id: p,
+                                surn: gedcom[p].name.surn,
+                                givn: gedcom[p].name.givn
+                            }
+                          } else {
                             return {
                                 id: p,
                                 surn: gedcom[p].surn || gedcom[p].name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1'),
                                 givn: gedcom[p].givn || gedcom[p].name.replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1')
                             }
+                          }
                         })
                     })
                     parents.forEach(p => {
                         gedcom[p].chil = f.chil.filter(c => gedcom[c]).map(c => {
+                          if (typeof gedcom[p].name === 'object' &&
+                            !Array.isArray(gedcom[p].name) &&
+                            gedcom[p].name !== null) {
+                            return {
+                                id: c,
+                                surn: gedcom[c].name.surn,
+                                givn: gedcom[c].name.givn
+                            }
+                          } else {
                             return {
                                 id: c,
                                 surn: gedcom[c].surn || gedcom[c].name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1'),
                                 givn: gedcom[c].givn || gedcom[c].name.replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1')
                             }
+                          }
                         })
                     })
                 }
@@ -139,14 +160,14 @@
                     if (!gedcom[f.wife].cons) { gedcom[f.wife].cons = [] }
                     gedcom[f.wife].cons.push({
                         id: f.husb,
-                        surn: gedcom[f.husb].surn || gedcom[f.husb].name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1'),
-                        givn: gedcom[f.husb].givn || gedcom[f.husb].name.replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1')
+                        surn: gedcom[f.husb].surn || gedcom[f.husb].name.surn || gedcom[f.husb].name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1'),
+                        givn: gedcom[f.husb].givn || gedcom[f.husb].name.givn || gedcom[f.husb].name.replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1')
                     });
                     if (!gedcom[f.husb].cons) { gedcom[f.husb].cons = [] }
                     gedcom[f.husb].cons.push({
                         id: f.wife,
-                        surn: gedcom[f.wife].surn || gedcom[f.wife].name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1'),
-                        givn: gedcom[f.wife].givn || gedcom[f.wife].name.replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1')
+                        surn: gedcom[f.wife].surn || gedcom[f.wife].name.surn || gedcom[f.wife].name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1'),
+                        givn: gedcom[f.wife].givn || gedcom[f.wife].name.givn || gedcom[f.wife].name.replace(/^(.*)\/\s*(.*)\s*\/.*$/,'$1')
                     });
                 }
             });

--- a/src/components/views/LinkSampleTable.svelte
+++ b/src/components/views/LinkSampleTable.svelte
@@ -354,16 +354,33 @@
                 const id = k;
                 let firstName = tree[k].surn;
                 let lastName = tree[k].givn;
-                const name = tree[k].name;
-                const normName = name.replace(/^\s*(Mr|Monsieur|Madame|Mme|M\.|Mrs)\s+/gi,'');
+                let name = tree[k].name;
                 const sex = tree[k].sex;
-                if (normName) {
-                    if (!firstName) {
-                        firstName = normName.replace(/^(.*)\s+\/.*$/,'$1');
-                    }
-                    if (!lastName) {
-                        lastName = name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1');
-                    }
+                if (typeof name === 'object' &&
+                  !Array.isArray(name) &&
+                  name !== null) {
+                  firstName = name.surn;
+                  lastName = name.givn;
+                  name = firstName + lastName;
+                  const normName = name.replace(/^\s*(Mr|Monsieur|Madame|Mme|M\.|Mrs)\s+/gi,'');
+                  if (normName) {
+                      if (!firstName) {
+                          firstName = normName.replace(/^(.*)\s+\/.*$/,'$1');
+                      }
+                      if (!lastName) {
+                          lastName = name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1');
+                      }
+                  }
+                } else {
+                  const normName = name.replace(/^\s*(Mr|Monsieur|Madame|Mme|M\.|Mrs)\s+/gi,'');
+                  if (normName) {
+                      if (!firstName) {
+                          firstName = normName.replace(/^(.*)\s+\/.*$/,'$1');
+                      }
+                      if (!lastName) {
+                          lastName = name.replace(/^.*\/\s*(.*)\s*\/.*$/,'$1');
+                      }
+                  }
                 }
                 let birthDate, birthPlace, birthCity, birthCountry, birthDep;
                 if (tree[k].birt) {


### PR DESCRIPTION
Gedcom support fails with composed names like
```json
"names": {
  "xxxxx":  "Robert Eugene /Williams/",
  "surn": "Williams",
  "givn":  "Robert Eugene"
}
``` 
example: https://www.gedcom.org/samples/555SAMPLE.GED