### PR TITLE
anonymize kids for preventive personal data protection, CNIL art 85 like

### DIFF
--- a/src/components/tools/search.js
+++ b/src/components/tools/search.js
@@ -237,6 +237,14 @@ const correct = (person) => {
             }
             person.death = undefined;
         }
+    } else if ( person.death && (person.death.age !== null) && (person.death.age >=0) && (person.death.age < 18) ) {
+        person.name.first = [ `${person.name.first[0][0]}****` ];
+        person.name.last = `${person.name.last[0]}****`;
+        person.birth.location = {
+            departmentCode: person.birth.location.departmentCode,
+            country: person.birth.location.country,
+            countryCode: person.birth.location.countryCode
+        }
     }
     return person;
   };

--- a/src/components/tools/search.js
+++ b/src/components/tools/search.js
@@ -237,7 +237,7 @@ const correct = (person) => {
             }
             person.death = undefined;
         }
-    } else if ( person.death && (person.death.age !== null) && (person.death.age >=0) && (person.death.age < 18) ) {
+    } else if ( person.death && (person.death.age !== null) && (person.death.age < 18) ) {
         person.name.first = [ `${person.name.first[0][0]}****` ];
         person.name.last = `${person.name.last[0]}****`;
         person.birth.location = {


### PR DESCRIPTION
L'implémentation anonymise le nom et prénom des jeunes décédés de moins de 18 ans, par respect pour leurs parents.
Cela génèrera du silence, pour les erreurs de saisie, mais cela reste un petit nombre (450000 données sur 26M).
Le matching complet reste accessible aux fonction d'appariement en masse, notamment pour permettre les retraits en masse de fichier.