### PR TITLE
Feat/anonymize kids

### DIFF
--- a/src/components/tools/search.js
+++ b/src/components/tools/search.js
@@ -254,6 +254,7 @@ const correct = (person) => {
                     countryCode: person.birth.location.countryCode
                 }
             }
+            person.anonymize = "recentKidDeath";
         }
     }
     return person;

--- a/src/components/tools/search.js
+++ b/src/components/tools/search.js
@@ -55,6 +55,11 @@ const f = fuzzySearch.subscribe((value) => {myFuzzySearch = value});
 const d = displayMode.subscribe((value) => {myDisplayMode = value});
 const u = updateURL.subscribe((value) => { myUpdateURL=value });
 
+const today = new Date(Date.now());
+const currentYear = today.getFullYear();
+const currentMonth = today.getMonth()+1;
+
+
 export const enableDisplayMode = async (mode) => {
     if (myDisplayMode) {
         if ((myDisplayMode === 'geo') && (mode !== 'geo')) {
@@ -238,12 +243,17 @@ const correct = (person) => {
             person.death = undefined;
         }
     } else if ( person.death && (person.death.age !== null) && (person.death.age < 18) ) {
-        person.name.first = [ `${person.name.first[0][0]}****` ];
-        person.name.last = `${person.name.last[0]}****`;
-        person.birth.location = {
-            departmentCode: person.birth.location.departmentCode,
-            country: person.birth.location.country,
-            countryCode: person.birth.location.countryCode
+        if (person.death.date) {
+            const deathSinceYears = currentYear - parseInt(person.death.date.substring(0,4)) - (currentMonth >= parseInt(person.death.date.substring(4,6)) ? 0 : 1);
+            if (deathSinceYears < 10) {
+                person.name.first = [ `${person.name.first[0][0]}****` ];
+                person.name.last = `${person.name.last[0]}****`;
+                person.birth.location = {
+                    departmentCode: person.birth.location.departmentCode,
+                    country: person.birth.location.country,
+                    countryCode: person.birth.location.countryCode
+                }
+            }
         }
     }
     return person;

--- a/src/components/views/ResultCard.svelte
+++ b/src/components/views/ResultCard.svelte
@@ -238,6 +238,14 @@
                                             </div>
                                         {/each}
                                     {/if}
+                                    {#if (result.anonymize && result.anonymize == "recentKidDeath") }
+                                            <div class="rf-col-xs-12 rf-col-sm-12 rf-col-md-12 rf-col-lg-12 rf-col-xl-12 rf-text--center rf-padding-top-1N">
+                                                <i>
+                                                    Du fait de la sensibilité de ces données personnelles, les décès de mineurs datant de moins de 10 ans sont anonymisés par défaut, pour limiter
+                                                    la vue grand public et l'indexation de ces données.
+                                                </i>
+                                            </div>
+                                    {/if}
                                     <div class="rf-col-12 rf-text--center rf-margin-top-2N">
                                         {#if edit && (Object.keys(editValue).length)}
                                             <p>


### PR DESCRIPTION
Suite à mail d'un généalogiste ralant sur les récentes anonymisation, j'essaye de ménager la chèvre et le choux : on n'anonymise les décès de mineurs que s'ils date de moins de 10 ans.

Ainsi, on laisse le temps au deuil, sans empêcher les recherches génalogiques sur des décès plus anciens.